### PR TITLE
FIX: Mersenne Twister MIN_INT definition change for GNU compiler

### DIFF
--- a/src/share/mersenne_twister.f
+++ b/src/share/mersenne_twister.f
@@ -173,8 +173,8 @@
         integer,parameter:: n=624
         integer,parameter:: m=397
         integer,parameter:: mata=-1727483681 ! constant vector a
-        integer,parameter:: umask=-2147483648 ! most significant w-r bits
-        integer,parameter:: lmask =2147483647 ! least significant r bits
+        integer,parameter:: lmask=HUGE(0) ! least significant r bits
+        integer,parameter:: umask=-lmask - 1 ! most significant w-r bits
         integer,parameter:: tmaskb=-1658038656 ! tempering parameter
         integer,parameter:: tmaskc=-272236544 ! tempering parameter
         integer,parameter:: mag01(0:1)=(/0,mata/)


### PR DESCRIPTION
gfortran complains about this being out of the int range, because it
negatives the positive value which _is_ out of range even though the
min can be represented. To fix this, we should negative MAX_INT and
subtract 1 which is done here.