### PR TITLE
Fix/ops g5 failure

### DIFF
--- a/src/gsm/dyn/gfs_dynamics_run_mod.f
+++ b/src/gsm/dyn/gfs_dynamics_run_mod.f
@@ -316,8 +316,8 @@
         do k=1,levs
           if(spdmax(k) < 0. .or. spdmax(k) > 2000.) then
             print *,'unphysical maximum speed',spdmax(k),' me=',me,' k=',k
-            call mpi_quit(7)
-            stop
+!            call mpi_quit(7)
+!            stop
           endif
         enddo
 

--- a/src/gsm/phys/gfs_physics_grid_comp_mod.f
+++ b/src/gsm/phys/gfs_physics_grid_comp_mod.f
@@ -652,7 +652,7 @@
           call read_ifp
       end if
 
-      kint = ((int_state%kdt - 1 + params % skip - params % kdt_start) * timestep_sec / params % ifp_interval) + 1
+      kint = ((int_state%kdt - 1 - params % kdt_start) * timestep_sec / params % ifp_interval) + 1 + params % skip
 
       if ( kint + 1 .le. size(farr % f107)) then
         wgt = 1 - real(mod((int_state%kdt-1)*timestep_sec, params % ifp_interval))/params % ifp_interval

--- a/src/phys/idea_getno_snoe.f
+++ b/src/phys/idea_getno_snoe.f
@@ -204,6 +204,7 @@
 ! locals
 !  we have         33, 16,7 now...
 !      real :: eof(33,16,3),nom(33,16),z16(16), lat33(33)
+      real, parameter :: no_fac = 3.
       real :: mlat          ! degrees like in snoe data
       real ::  zm(no_nz16)
       real ::  dz(levs)
@@ -310,11 +311,10 @@
           no(k)=max(no(k), con_nzero)
         enddo
 !
-! multiply NO by a linearly-scaled factor when kpa>=5.0
-! up to 100% increase at Kpa 9.0
+! multiply NO by a linearly-scaled factor (defined above) when kpa>=5.0
 !
         if (kpa.ge.5.0) then
-          no = no * (1. +  (kpa - 5.) * ( 2. - 1. ) / (9. - 5.) )
+          no = no * (1. +  (kpa - 5.) * ( no_fac - 1. ) / (9. - 5.) )
         endif
 !
 !

--- a/src/phys/idea_getno_snoe.f
+++ b/src/phys/idea_getno_snoe.f
@@ -310,20 +310,12 @@
           no(k)=max(no(k), con_nzero)
         enddo
 !
-! incease NO by a factor when kpa gt 5.0, same with CTIPe, based on CHAMP
-! neutral density obervations 
-!  
-        do k=1,levs
-          if (kpa.gt.5.0.and.kpa.le.6.0) then
-            no(k) = no(k)*1.5
-          elseif (kpa.gt.6.0.and.kpa.le.7.0) then
-            no(k) = no(k)*2.5
-          elseif (kpa.gt.7.0.and.kpa.le.8.0) then
-            no(k) = no(k)*3.5
-          elseif (kpa.gt.8.0.and.kpa.le.9.0) then
-            no(k) = no(k)*4.5
-          endif
-        enddo
+! multiply NO by a linearly-scaled factor when kpa>=5.0
+! up to 100% increase at Kpa 9.0
+!
+        if (kpa.ge.5.0) then
+          no = no * (1. +  (kpa - 5.) * ( 2. - 1. ) / (9. - 5.) )
+        endif
 !
 !
 ! check no


### PR DESCRIPTION
This PR accomplishes three things:

1. Remove hard stop for neutral wind speeds in excess of 2km/s.
2. Address bug that fed the model incorrect drivers when using a timestep of anything other than 60 seconds.
3. Replace the step function NO cooling with a max 350% increase at Kpa 8-9 with a linearly scaled maximum of 200% at Kpa 9. This improves model stability, among other benefits.

This has been tested extensively, particularly through the 2003 Halloween Storm and the 2024 G5 event.